### PR TITLE
Clean up TrailerSeparator on the path to 1.0

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -75,6 +75,9 @@ pub enum FooterSeparator {
 
     /// " #"
     SpacePound,
+
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl Deref for FooterSeparator {
@@ -84,16 +87,14 @@ impl Deref for FooterSeparator {
         match self {
             FooterSeparator::ColonSpace => ": ",
             FooterSeparator::SpacePound => " #",
+            FooterSeparator::__NonExhaustive => "",
         }
     }
 }
 
 impl fmt::Display for FooterSeparator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FooterSeparator::ColonSpace => f.write_str(": "),
-            FooterSeparator::SpacePound => f.write_str(" #"),
-        }
+        f.write_str(self)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,10 +5,17 @@ use std::fmt;
 /// The error returned when parsing a commit fails.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
-    commit: String,
-
     /// The kind of error.
     pub kind: Kind,
+
+    commit: Option<String>,
+}
+
+impl Error {
+    /// Create a new error from a `Kind`.
+    pub(crate) fn new(kind: Kind) -> Self {
+        Self { kind, commit: None }
+    }
 }
 
 /// All possible error kinds returned when parsing a conventional commit.
@@ -77,7 +84,7 @@ impl<'a> From<(&'a str, nom::Err<nom::error::VerboseError<&'a str>>)> for Error 
         };
 
         Self {
-            commit: commit.to_owned(),
+            commit: Some(commit.to_owned()),
             kind,
         }
     }


### PR DESCRIPTION
In #11, some issues called out include
- `TrailerSeparator` cannot have new variants added without breaking the API
- `impl From` will panic on unsupported values.  I considered making the conversion private which would let it keep panicing (since the parser would prevent that) but since the API for `TrailerSeparator` is so tied to strings, I thought it made sense to go ahead and expose this.

This addresses those issues.