### PR TITLE
Make `conventional` easier to use

### DIFF
--- a/src/commit/simple.rs
+++ b/src/commit/simple.rs
@@ -1,22 +1,21 @@
 //! Conventional Commit implementations.
 
 use crate::{Commit, SimpleFooter};
-use std::ops::Deref;
 
 /// The weakly-typed variant of a commit.
-pub trait Simple {
+pub trait Simple<'a> {
     /// The type of the commit.
-    fn type_(&self) -> &str;
+    fn type_(&self) -> &'a str;
 
     /// The optional scope of the commit.
-    fn scope(&self) -> Option<&str>;
+    fn scope(&self) -> Option<&'a str>;
 
     /// The commit description.
-    fn description(&self) -> &str;
+    fn description(&self) -> &'a str;
 
     /// The commit body, containing a more detailed explanation of the commit
     /// changes.
-    fn body(&self) -> Option<&str>;
+    fn body(&self) -> Option<&'a str>;
 
     /// A flag to signal that the commit contains breaking changes.
     ///
@@ -39,34 +38,34 @@ pub trait Simple {
     /// requiring whitespace before newlines.
     ///
     /// See: <https://git-scm.com/docs/git-interpret-trailers>
-    fn footers(&self) -> Vec<SimpleFooter<'_>>;
+    fn footers(&self) -> Vec<SimpleFooter<'a>>;
 }
 
-impl Simple for Commit<'_> {
-    fn type_(&self) -> &str {
-        &self.ty
+impl<'a> Simple<'a> for Commit<'a> {
+    fn type_(&self) -> &'a str {
+        self.ty.as_str()
     }
 
-    fn scope(&self) -> Option<&str> {
-        self.scope.as_ref().map(Deref::deref)
+    fn scope(&self) -> Option<&'a str> {
+        self.scope.as_ref().map(|s| s.as_str())
     }
 
-    fn description(&self) -> &str {
-        &self.description
+    fn description(&self) -> &'a str {
+        self.description.as_str()
     }
 
-    fn body(&self) -> Option<&str> {
-        self.body.as_ref().map(Deref::deref)
+    fn body(&self) -> Option<&'a str> {
+        self.body.as_ref().map(|s| s.as_str())
     }
 
     fn breaking(&self) -> bool {
         self.breaking
     }
 
-    fn footers(&self) -> Vec<SimpleFooter<'_>> {
+    fn footers(&self) -> Vec<SimpleFooter<'a>> {
         self.footers
             .iter()
-            .map(|footer| SimpleFooter { footer })
+            .map(|footer| SimpleFooter { footer: *footer })
             .collect::<Vec<_>>()
     }
 }

--- a/src/commit/typed.rs
+++ b/src/commit/typed.rs
@@ -1,6 +1,4 @@
 //! Conventional Commit implementations.
-//! Conventional Commit implementations.
-//! Conventional Commit implementations.
 
 use crate::typed::{Body, Description, Footer, Scope, Type};
 use crate::Commit;

--- a/src/component.rs
+++ b/src/component.rs
@@ -44,7 +44,7 @@ impl<'a> Footer<'a> {
 /// values of its components.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct SimpleFooter<'a> {
-    pub(crate) footer: &'a Footer<'a>,
+    pub(crate) footer: Footer<'a>,
 }
 
 impl<'a> SimpleFooter<'a> {

--- a/src/component.rs
+++ b/src/component.rs
@@ -77,15 +77,22 @@ pub enum FooterSeparator {
     __NonExhaustive,
 }
 
-impl Deref for FooterSeparator {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
+impl FooterSeparator {
+    /// Access `str` representation of FooterSeparator
+    pub fn as_str(self) -> &'static str {
         match self {
             FooterSeparator::ColonSpace => ": ",
             FooterSeparator::SpacePound => " #",
             FooterSeparator::__NonExhaustive => unreachable!(),
         }
+    }
+}
+
+impl Deref for FooterSeparator {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
     }
 }
 
@@ -119,13 +126,18 @@ macro_rules! components {
             pub fn new(value: &'a str) -> Self {
                 $ty(value)
             }
+
+            /// Access `str` representation of $ty
+            pub fn as_str(&self) -> &'a str {
+                &self.0
+            }
         }
 
         impl Deref for $ty<'_> {
             type Target = str;
 
             fn deref(&self) -> &Self::Target {
-                &self.0
+                self.as_str()
             }
         }
 
@@ -156,13 +168,18 @@ macro_rules! unicase_components {
                 pub fn new(value: &'a str) -> Self {
                     $ty(unicase::UniCase::new(value))
                 }
+
+                /// Access `str` representation of $ty
+                pub fn as_str(&self) -> &'a str {
+                    &self.0.into_inner()
+                }
             }
 
             impl Deref for $ty<'_> {
                 type Target = str;
 
                 fn deref(&self) -> &Self::Target {
-                    &self.0.into_inner()
+                    self.as_str()
                 }
             }
 


### PR DESCRIPTION
I've started porting my code to `conventional`.  I started with `Typed` but I needed access to the `str`s and ran into problems with that, so I thought I'd try `Simple`.  Unfortunately, the lifetimes were off with `Simple` so that didn't work also.